### PR TITLE
style: update ascribe syntax

### DIFF
--- a/src/Locale.flix
+++ b/src/Locale.flix
@@ -419,7 +419,7 @@ mod Locale {
     
     def fromSetAsList(l: ##java.util.Set): List[a] = region rc {
         import java.util.Set.iterator(): ##java.util.Iterator \ rc;
-        iterator(l) |> Adaptor.fromIterator(rc, Proxy.Proxy: Proxy[a]) |> Iterator.toList
+        iterator(l) |> Adaptor.fromIterator(rc, (Proxy.Proxy: Proxy[a])) |> Iterator.toList
     }
 
     def charFromJava(c: ##java.lang.Character): Char = 


### PR DESCRIPTION
Updates the syntax of type ascriptions. They now require surrounding parenthesis.
```scala
// Before
x: Int32
// After
(x: Int32)
```