### PR TITLE
rename `new` -> `make`

### DIFF
--- a/src/Locale.flix
+++ b/src/Locale.flix
@@ -113,7 +113,7 @@ mod Locale {
     ///
     /// Returns a new Locale for the supplied language.
     ///
-    pub def new(lang: String): Locale =
+    pub def make(lang: String): Locale =
         import java_new java.util.Locale(String): ##java.util.Locale \ {} as new1;
         Locale(new1(lang))
 


### PR DESCRIPTION
With the new parser `new` is treated as a keyword and can no longer be used as a name. I suggest renaming to `make` but another alternative is fine too.